### PR TITLE
Take absolute value to allow import of historical data

### DIFF
--- a/Source/WPF/MyMoney/Database/Money.cs
+++ b/Source/WPF/MyMoney/Database/Money.cs
@@ -7850,7 +7850,7 @@ namespace Walkabout.Data
             // 'u' is a real transaction
             // 't' is a potential merge transaction.
 
-            TimeSpan span = (dt - udt);
+            TimeSpan span = (dt - udt).Duration();
             if (span.TotalHours < 24)
             {
                 return true;


### PR DESCRIPTION
When importing historical data the timespan was coming back negative and some similar transactions were not being included.
Fixed by taking the absolute duration.