### PR TITLE
Add alias management by auto-removing subsumed aliases

### DIFF
--- a/Source/WPF/MyMoney/Controls/QuickFilterControl.xaml
+++ b/Source/WPF/MyMoney/Controls/QuickFilterControl.xaml
@@ -12,7 +12,7 @@
 
     <Grid x:Name="LayoutRoot">
         <Border x:Name="QuickFilter"
-                Background="#55aaaaaa"
+                Background="{DynamicResource AppBarToggleButtonBackground}"
                 SnapsToDevicePixels="True">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -37,7 +37,6 @@
 
                 <!-- TEXT BOX GLASS -->
                 <TextBox Name="InputFilterText" Grid.Column="1" BorderThickness="0" 
-                         Background="Transparent"
                          VerticalAlignment="Center" 
                          HorizontalAlignment="Stretch"  
                          KeyUp="OnTextBox_KeyUp" 

--- a/Source/WPF/MyMoney/Controls/WpfConverters.cs
+++ b/Source/WPF/MyMoney/Controls/WpfConverters.cs
@@ -101,6 +101,41 @@ namespace Walkabout.WpfConverters
         }
     }
 
+    public class DeletedAliasToolTipConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b && b == true)
+        {
+            return "This alias has been subsumed by another and will be deleted when you save your changes";
+        }
+
+        return DependencyProperty.UnsetValue;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value;
+    }
+}
+
+public class StrikeThroughConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool b && b == true)
+            {
+                return TextDecorations.Strikethrough;
+            }
+
+            return DependencyProperty.UnsetValue;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
 
     public class NullableValueConverter : IValueConverter
     {
@@ -116,8 +151,6 @@ namespace Walkabout.WpfConverters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            //if (string.IsNullOrEmpty(value.ToString()))
-            //    return null;
             return value;
         }
 

--- a/Source/WPF/MyMoney/Database/Money_Loans.cs
+++ b/Source/WPF/MyMoney/Database/Money_Loans.cs
@@ -88,9 +88,14 @@ namespace Walkabout.Data
         // todo: there should be no references left at this point...
         public bool Remove(LoanPayment x)
         {
+            return RemoveLoan(x);
+        }
+
+        internal bool RemoveLoan(LoanPayment x, bool forceRemoveAfterSave = false)
+        { 
             lock (collection)
             {
-                if (x.IsInserted)
+                if (x.IsInserted || forceRemoveAfterSave)
                 {
                     //// nothing to sync then
                     if (this.collection.Contains(x.Id))
@@ -141,9 +146,9 @@ namespace Walkabout.Data
             Add((LoanPayment)child);
         }
 
-        public override void RemoveChild(PersistentObject pe)
+        public override void RemoveChild(PersistentObject pe, bool forceRemoveAfterSave = false)
         {
-            Remove((LoanPayment)pe);
+            RemoveLoan((LoanPayment)pe, forceRemoveAfterSave);
         }
 
         public bool IsReadOnly

--- a/Source/WPF/MyMoney/Dialogs/RenamePayeeDialog.xaml
+++ b/Source/WPF/MyMoney/Dialogs/RenamePayeeDialog.xaml
@@ -57,7 +57,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
-
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -91,7 +91,15 @@
                         Auto-Rename ( make this an ongoing rename )
                     </CheckBox>
                 </Border>
+
+                <TextBlock x:Name="ClashPromp" Grid.Row="5" Margin="0,10,0,0" Text="These existing aliases will be subsumed by your new alias:"
+                           TextWrapping="Wrap" Grid.ColumnSpan="2" Visibility="Collapsed"/>
+
+                <ListView x:Name="ClashingAliases" Grid.Row="6" Margin="0,0,0,0" ScrollViewer.VerticalScrollBarVisibility="Visible"
+                          MaxHeight="300" Grid.ColumnSpan="2"  Visibility="Collapsed">
+                </ListView>
             </Grid >
+            
 
         </Border>
 

--- a/Source/WPF/MyMoney/Setup/changes.xml
+++ b/Source/WPF/MyMoney/Setup/changes.xml
@@ -2,6 +2,9 @@
 <changes>
   <change version="2.0.0.2" date="2/24/2022">
     - Add "Export List" to Accounts panel to generate csv of the current accounts list.
+    - Fix 'merge ui' so the braces always point to the right place even during scrolling.
+    - Resolve issue #32: Better management of Aliases.
+    - Fix color of quick search box caret in dark theme.
   </change>
   <change version="2.0.0.1" date="2/22/2022">
     - Normalize account balances in account view.

--- a/Source/WPF/MyMoney/Themes/Dark.xaml
+++ b/Source/WPF/MyMoney/Themes/Dark.xaml
@@ -25,6 +25,9 @@
 
     <!-- OFX download panel -->
     <SolidColorBrush x:Key="SyncronizingIconBrush" Color="{m:DynamicColor SystemAccentColor}"/>
+    
+    <!-- secton headers -->
+    <SolidColorBrush x:Key="SectionHeaderBorder" Color="gray"/>
 
     <!-- colors for list selection -->
     <SolidColorBrush x:Key="ListItemForegroundUnacceptedBrush" Color="#D7BA7D"/>

--- a/Source/WPF/MyMoney/Themes/Light.xaml
+++ b/Source/WPF/MyMoney/Themes/Light.xaml
@@ -22,6 +22,9 @@
     <!-- MessageBox border -->
     <SolidColorBrush x:Key="MessageBoxBorder" Color="{m:DynamicColor SystemAccentColor}"/>
 
+    <!-- secton headers -->
+    <SolidColorBrush x:Key="SectionHeaderBorder" Color="gray"/>
+
     <!-- OFX download panel -->
     <SolidColorBrush x:Key="SyncronizingIconBrush" Color="{m:DynamicColor SystemAccentColor}"/>
     

--- a/Source/WPF/MyMoney/View Selectors/AccountsControl.xaml
+++ b/Source/WPF/MyMoney/View Selectors/AccountsControl.xaml
@@ -12,21 +12,21 @@
     <UserControl.Resources>
 
         <DataTemplate DataType="{x:Type local:AccountSectionHeader}">
-            <Border BorderThickness="0 0 0 1" BorderBrush="Gray" Margin="0 10 0 0">
-                    <Grid>
+            <Border BorderThickness="0 0 0 1" BorderBrush="{DynamicResource SectionHeaderBorder}" Margin="0 10 0 0">
+                <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
                     <TextBlock Grid.Column="0" Text="{Binding Title}"
-                               FontSize="20"/>
+                                FontSize="20"/>
 
                     <TextBlock Grid.Column="1" Text="{Binding BalanceInNormalizedCurrencyValue, StringFormat={}{0:C}}"  
-							   HorizontalAlignment="Right" 
-                               Foreground="{Binding BalanceForeground}"
-                               />
-                    </Grid>
+							       HorizontalAlignment="Right" 
+                                   Foreground="{Binding BalanceForeground}"
+                                   />
+                </Grid>
             </Border>
         </DataTemplate>
 

--- a/Source/WPF/MyMoney/View Selectors/AccountsControl.xaml.cs
+++ b/Source/WPF/MyMoney/View Selectors/AccountsControl.xaml.cs
@@ -1010,7 +1010,7 @@ namespace Walkabout.Views.Controls
             }
         }
 
-        public Uri WarningIcon
+        public object WarningIcon
         {
             get
             {
@@ -1018,7 +1018,7 @@ namespace Walkabout.Views.Controls
                 {
                     return new Uri("pack://application:,,,/MyMoney;component/Dialogs/Icons/Warning.png");
                 }
-                return null;
+                return DependencyProperty.UnsetValue;
             }
         }
 

--- a/Source/WPF/MyMoney/Views/AliasesView.xaml
+++ b/Source/WPF/MyMoney/Views/AliasesView.xaml
@@ -46,12 +46,16 @@
         </Style>
 
         <c:NullableValueConverter x:Key="NullableValueConverter" />
+        <c:StrikeThroughConverter x:Key="StrikeThroughConverter"/>
+        <c:DeletedAliasToolTipConverter x:Key="DeletedAliasToolTipConverter"/>
 
         <!-- Pattern -->
         <DataTemplate x:Key="myTemplatePattern">
             <!-- the border makes the whole column hitable -->
             <Border BorderThickness="0,0,0,0" Background="Transparent" Focusable="false" VerticalAlignment="Stretch" Padding="5,0">
-                <TextBlock Text="{Binding Path=Pattern, Converter={StaticResource NullableValueConverter}}" />
+                <TextBlock Text="{Binding Path=Pattern, Converter={StaticResource NullableValueConverter}}"
+                           TextDecorations="{Binding Path=IsDeleted, Converter={StaticResource StrikeThroughConverter }}"
+                           ToolTip="{Binding Path=IsDeleted, Converter={StaticResource DeletedAliasToolTipConverter}}"/>
             </Border>
         </DataTemplate>
 
@@ -67,7 +71,9 @@
         <DataTemplate x:Key="myTemplateType">
             <!-- the border makes the whole column hitable -->
             <Border BorderThickness="0,0,0,0" Background="Transparent" Focusable="false" VerticalAlignment="Stretch" Padding="5,0">
-                <TextBlock Text="{Binding Path=AliasType, Converter={StaticResource NullableValueConverter}}" />
+                <TextBlock Text="{Binding Path=AliasType, Converter={StaticResource NullableValueConverter}}"
+                           TextDecorations="{Binding Path=IsDeleted, Converter={StaticResource StrikeThroughConverter }}"
+                           ToolTip="{Binding Path=IsDeleted, Converter={StaticResource DeletedAliasToolTipConverter}}"/>
             </Border>
         </DataTemplate>
 
@@ -83,7 +89,9 @@
         <DataTemplate x:Key="myTemplatePayee">
             <!-- the border makes the whole column hitable -->
             <Border BorderThickness="0,0,0,0" Background="Transparent" Focusable="false" VerticalAlignment="Stretch" Padding="5,0">
-                <TextBlock Text="{Binding Path=Payee, Converter={StaticResource NullableValueConverter}}" />
+                <TextBlock Text="{Binding Path=Payee, Converter={StaticResource NullableValueConverter}}" 
+                           TextDecorations="{Binding Path=IsDeleted, Converter={StaticResource StrikeThroughConverter }}"
+                           ToolTip="{Binding Path=IsDeleted, Converter={StaticResource DeletedAliasToolTipConverter}}"/>
             </Border>
         </DataTemplate>
 
@@ -157,7 +165,7 @@
         <StackPanel x:Name="SearchWidgetArea"  Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,2,2,2" VerticalAlignment="Top" >
 
             <!-- QUICK FILTER -->
-            <local:QuickFilterControl x:Name="QuickFilterUX"  Width="144" FilterValueChanged="OnQuickFilterValueChanged" HorizontalAlignment="Left"/>
+            <local:QuickFilterControl x:Name="QuickFilterUX"  Width="200" FilterValueChanged="OnQuickFilterValueChanged" HorizontalAlignment="Left"/>
 
         </StackPanel>
     </Grid>

--- a/Source/WPF/MyMoney/Views/FlowDocumentView.xaml
+++ b/Source/WPF/MyMoney/Views/FlowDocumentView.xaml
@@ -47,7 +47,7 @@
                     <StackPanel x:Name="SearchWidgetArea"  Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,2,2,2" VerticalAlignment="Center" >
 
                         <!-- QUICK FILTER -->
-                        <c:QuickFilterControl x:Name="QuickFilterUX"  Width="144" FilterValueChanged="OnQuickFilterValueChanged" HorizontalAlignment="Left"/>
+                        <c:QuickFilterControl x:Name="QuickFilterUX"  Width="200" FilterValueChanged="OnQuickFilterValueChanged" HorizontalAlignment="Left"/>
 
                         <!-- ADVANCE & CLOSE -->
                         <c:TabCloseBox x:Name="CloseReport" Click="OnCloseReport" VerticalAlignment="Center" Margin="5,0,2,0"/>

--- a/Source/WPF/MyMoney/Views/SecuritiesView.xaml
+++ b/Source/WPF/MyMoney/Views/SecuritiesView.xaml
@@ -538,7 +538,7 @@
                 <StackPanel x:Name="SearchWidgetArea"  Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,2,2,2" VerticalAlignment="Center" >
 
                     <!-- QUICK FILTER -->
-                    <local:QuickFilterControl x:Name="QuickFilterUX"  Width="144" FilterValueChanged="OnQuickFilterValueChanged" HorizontalAlignment="Left"/>
+                    <local:QuickFilterControl x:Name="QuickFilterUX"  Width="200" FilterValueChanged="OnQuickFilterValueChanged" HorizontalAlignment="Left"/>
 
                 </StackPanel>
             </Grid>


### PR DESCRIPTION
When adding a `Regex` Alias in the alias view, often-times these subsume a bunch of non-regex aliases.  This change highlights this fact by auto-removing them, first with a strike through showing what will be deleted, then they are removed on Save.

https://user-images.githubusercontent.com/3336415/155929373-9690e994-73a1-4bb0-9789-27c48f83a71d.mp4

Similarly, the RenamePayee dialog now shows all the aliases that will be subsumed if you used the RenamePayeeDialog to create a new Alias (the `Auto Rename` check box).

https://user-images.githubusercontent.com/3336415/155929390-3c3530c0-aeaa-4472-bc7e-16321a9d19cc.mp4


