### PR TITLE
Replace the NewLine character with a space to prevent SQL syntax errors

### DIFF
--- a/Source/WPF/MyMoney/Ofx/Ofx.cs
+++ b/Source/WPF/MyMoney/Ofx/Ofx.cs
@@ -1845,7 +1845,7 @@ NEWFILEUID:{1}
                     XText text = node as XText;
                     if (text != null)
                     {
-                        text.Value = text.Value.Trim();
+                        text.Value = text.Value.Trim().Replace(Environment.NewLine, " ");
                     }
                 }
 


### PR DESCRIPTION
This is to prevent SQL errors like the following while inserting payees from an OFX file

> Error executing SQL "-- inserting payee: Withdrawal
\<snip Sensitive Info> 4252-ABC D
INSERT INTO Payees (Id, Name) VALUES (491,'Withdrawal
\<snip Sensitive Info> 4252-ABC D');
"
SQL logic error
near "\<snip Sensitive Info>": syntax error

The transaction in the OFX file looks like this
![image](https://user-images.githubusercontent.com/1530360/180630903-52a1d544-be94-4433-9a38-e47ed30220cd.png)