### PR TITLE
Add ability to pick a date on the NetworthReport

### DIFF
--- a/Source/WPF/MyMoney/Database/CostBasis.cs
+++ b/Source/WPF/MyMoney/Database/CostBasis.cs
@@ -266,7 +266,7 @@ namespace Walkabout.Data
         public IEnumerable<SecuritySale> Sell(DateTime dateSold, decimal units, decimal amount)
         {
             decimal salePricePerUnit = amount / units;
-
+            List<SecuritySale> result = new List<SecuritySale>();
             foreach (var purchase in list)
             {
                 SecuritySale sale = purchase.Sell(dateSold, units, salePricePerUnit);
@@ -274,7 +274,7 @@ namespace Walkabout.Data
                 {
                     sale.Account = this.Account;
                     units -= sale.UnitsSold;
-                    yield return sale;
+                    result.Add(sale);
 
                     if (units <= 0)
                     {
@@ -296,6 +296,7 @@ namespace Walkabout.Data
                     SalePricePerUnit = salePricePerUnit
                 });
             }
+            return result;
         }
 
         internal IEnumerable<SecuritySale> GetPendingSales()
@@ -308,25 +309,29 @@ namespace Walkabout.Data
             // now that more has arrived, time to see if we can process those pending sales.
             List<SecuritySale> copy = new List<SecuritySale>(this.pending);
             this.pending.Clear();
+            List<SecuritySale> result = new List<SecuritySale>();
             foreach (SecuritySale s in copy)
             {
                 // this will put any remainder back in the pending list if it still can't be covered.
                 foreach (SecuritySale real in Sell(s.DateSold, s.UnitsSold, s.UnitsSold * s.SalePricePerUnit))
                 {
-                    yield return real;
+                    result.Add(real);
                 }
             }
+            return result;
         }
 
         internal IEnumerable<SecurityPurchase> GetHoldings()
         {
+            List<SecurityPurchase> result = new List<SecurityPurchase>();
             foreach (SecurityPurchase sp in list)
             {
                 if (sp.UnitsRemaining > 0)
                 {
-                    yield return sp;
+                    result.Add(sp);
                 }
             }
+            return result;
         }
     }
 
@@ -348,13 +353,15 @@ namespace Walkabout.Data
         /// <returns></returns>
         public IEnumerable<SecurityPurchase> GetHoldings()
         {
+            List<SecurityPurchase> result = new List<SecurityPurchase>();
             foreach (SecurityFifoQueue queue in queues.Values) 
             {
                 foreach (SecurityPurchase p in queue.GetHoldings())
                 {
-                    yield return p;
+                    result.Add(p);
                 }
             }
+            return result;
         }
 
         /// <summary>
@@ -363,14 +370,16 @@ namespace Walkabout.Data
         /// <returns></returns>
         public IEnumerable<SecurityPurchase> GetPurchases(Security security)
         {
+            List<SecurityPurchase> result = new List<SecurityPurchase>();
             SecurityFifoQueue queue = null;
             if (queues.TryGetValue(security, out queue))
             {                
                 foreach (SecurityPurchase p in queue.GetHoldings())
                 {
-                    yield return p;
+                    result.Add(p);
                 }
             }
+            return result;
         }
 
         /// <summary>
@@ -435,25 +444,29 @@ namespace Walkabout.Data
     
         internal IEnumerable<SecuritySale> GetPendingSales()
         {
+            List<SecuritySale> result = new List<SecuritySale>();
             foreach (var queue in this.queues.Values) 
             {
                 foreach (SecuritySale sale in queue.GetPendingSales())
                 {
-                    yield return sale;
+                    result.Add(sale);
                 }
             }
+            return result;
         }
 
         internal IEnumerable<SecuritySale> GetPendingSalesForSecurity(Security s)
         {
+            List<SecuritySale> result = new List<SecuritySale>();
             SecurityFifoQueue queue;
             if (queues.TryGetValue(s, out queue))
             {
                 foreach (SecuritySale sale in queue.GetPendingSales())
                 {
-                    yield return sale;
+                    result.Add(sale);
                 }
             }
+            return result;
         }
     }
 
@@ -705,6 +718,7 @@ namespace Walkabout.Data
 
         public IEnumerable<SecuritySale> GetPendingSales(Predicate<Account> forAccounts)
         {
+            List<SecuritySale> result = new List<SecuritySale>();
             foreach (var pair in byAccount)
             {
                 Account a = pair.Key;
@@ -712,10 +726,11 @@ namespace Walkabout.Data
                 {
                     foreach (SecuritySale pending in pair.Value.GetPendingSales())
                     {
-                        yield return pending;
+                        result.Add(pending);
                     }
                 }
             }
+            return result;
         }
 
     }

--- a/Source/WPF/MyMoney/Database/Money.cs
+++ b/Source/WPF/MyMoney/Database/Money.cs
@@ -1929,12 +1929,11 @@ namespace Walkabout.Data
         }
 
         /// <summary>
-        /// Get the cash balance of the given investment account.  If the account is null
-        /// it returns the cash balance of all investment accounts.
+        /// Get the cash balance of the filtered accounts up to the given date.
         /// </summary>
-        /// <param name="account">The account or null</param>
+        /// <param name="filter">The account filter predicate to decide which accounts to include.</param>
         /// <returns>Cash balance</returns>
-        public decimal GetInvestmentCashBalanceNormalized(Predicate<Account> filter)
+        public decimal GetCashBalanceNormalized(DateTime date, Predicate<Account> filter)
         {
             decimal cash = 0;
             foreach (Account a in this.Accounts.GetAccounts(false))
@@ -1944,6 +1943,10 @@ namespace Walkabout.Data
                     decimal balance = a.OpeningBalance;
                     foreach (Transaction t in this.Transactions.GetTransactionsFrom(a))
                     {
+                        if (t.Date > date)
+                        {
+                            break;
+                        }
                         balance += t.Amount;
                     }
                     cash += a.GetNormalizedAmount(balance);

--- a/Source/WPF/MyMoney/Database/Money.cs
+++ b/Source/WPF/MyMoney/Database/Money.cs
@@ -1915,7 +1915,7 @@ namespace Walkabout.Data
 
             CostBasisCalculator calc = new CostBasisCalculator(this, DateTime.Now);
 
-            foreach (var group in calc.GetHoldingsBySecurityType(null))
+            foreach (var group in calc.GetHoldingsBySecurityType(TaxStatus.Any, null))
             {
                 foreach (SecurityPurchase sp in group.Purchases)
                 {
@@ -2316,7 +2316,8 @@ namespace Walkabout.Data
     {
         Taxable = 0,
         TaxDeferred = 1,
-        TaxFree = 2
+        TaxFree = 2,
+        Any = 3
     }
 
     [Flags]

--- a/Source/WPF/MyMoney/MainWindow.xaml.cs
+++ b/Source/WPF/MyMoney/MainWindow.xaml.cs
@@ -3382,9 +3382,9 @@ namespace Walkabout
             view.Closed -= new EventHandler(OnFlowDocumentViewClosed);
             view.Closed += new EventHandler(OnFlowDocumentViewClosed);
             HelpService.SetHelpKeyword(view, "Networth Report");
-            NetWorthReport report = new NetWorthReport(this.myMoney);
+            NetWorthReport report = new NetWorthReport(view, this.myMoney, this.quotes.DownloadLog);
             report.DrillDown += OnReportDrillDown;
-            view.Generate(report);
+            _ = view.Generate(report);
         }
 
         private void OnCommandReportInvestment(object sender, ExecutedRoutedEventArgs e)
@@ -3402,7 +3402,7 @@ namespace Walkabout
             HelpService.SetHelpKeyword(view, "Investment Portfolio");
             PortfolioReport report = new PortfolioReport(view, this.myMoney, null, this, DateTime.Now, null);
             report.DrillDown += OnReportDrillDown;
-            view.Generate(report);
+            _ = view.Generate(report);
         }
 
         private void OnReportDrillDown(object sender, SecurityGroup e)
@@ -3415,7 +3415,7 @@ namespace Walkabout
             view.Closed += new EventHandler(OnFlowDocumentViewClosed);
             HelpService.SetHelpKeyword(view, "Investment Portfolio - " + e.Type);
             PortfolioReport report = new PortfolioReport(view, this.myMoney, null, this, DateTime.Now, e);
-            view.Generate(report);
+            _ = view.Generate(report);
         }
 
         private void OnTaxReport(object sender, ExecutedRoutedEventArgs e)
@@ -3427,7 +3427,7 @@ namespace Walkabout
             view.Closed += new EventHandler(OnFlowDocumentViewClosed);
             HelpService.SetHelpKeyword(view, "Tax Report");
             TaxReport report = new TaxReport(view, this.myMoney, this.settings.FiscalYearStart);
-            view.Generate(report);
+            _ = view.Generate(report);
         }
 
         private void OnCommandW2Report(object sender, ExecutedRoutedEventArgs e)
@@ -3439,7 +3439,7 @@ namespace Walkabout
             view.Closed += new EventHandler(OnFlowDocumentViewClosed);
             HelpService.SetHelpKeyword(view, "W2 Report");
             W2Report report = new W2Report(view, this.myMoney, this, settings.FiscalYearStart);
-            view.Generate(report);
+            _ = view.Generate(report);
         }
 
         private void HasActiveAccount(object sender, CanExecuteRoutedEventArgs e)
@@ -4338,7 +4338,7 @@ namespace Walkabout
                 HelpService.SetHelpKeyword(view, "Updates");
                 ChangeInfoFormatter report = new ChangeInfoFormatter(view, installButton, previousVersion, changeList);
                 report.InstallButtonClick += OnInstallButtonClick;
-                view.Generate(report);
+                _ = view.Generate(report);
             }
         }
 

--- a/Source/WPF/MyMoney/MyMoney.csproj
+++ b/Source/WPF/MyMoney/MyMoney.csproj
@@ -224,6 +224,7 @@
     <Compile Include="StockQuotes\AlphaVantage.cs" />
     <Compile Include="StockQuotes\IEXCloud.cs" />
     <Compile Include="StockQuotes\IStockQuoteService.cs" />
+    <Compile Include="StockQuotes\StockQuoteCache.cs" />
     <Compile Include="StockQuotes\StockQuoteThrottle.cs" />
     <Compile Include="Utilities\AnimatedMessage.cs" />
     <Compile Include="Utilities\AppTheme.cs" />

--- a/Source/WPF/MyMoney/Reports/CashFlowReport.cs
+++ b/Source/WPF/MyMoney/Reports/CashFlowReport.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -198,10 +199,10 @@ namespace Walkabout.Reports
 
         public void Regenerate()
         {
-            view.Generate(this);
+            _ = view.Generate(this);
         }
 
-        public override void Generate(IReportWriter writer)
+        public override Task Generate(IReportWriter writer)
         {            
             byCategory = new Dictionary<Category, CashFlowColumns>();
 
@@ -319,6 +320,7 @@ namespace Walkabout.Reports
 
             writer.WriteParagraph("Generated on " + DateTime.Today.ToLongDateString(), System.Windows.FontStyles.Italic, System.Windows.FontWeights.Normal, System.Windows.Media.Brushes.Gray);
 
+            return Task.CompletedTask;
         }
 
         private void OnNextClick(object sender, RoutedEventArgs e)

--- a/Source/WPF/MyMoney/Reports/IReport.cs
+++ b/Source/WPF/MyMoney/Reports/IReport.cs
@@ -1,11 +1,12 @@
-﻿using System.Windows;
+﻿using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Media;
 
 namespace Walkabout.Interfaces.Reports
 {
     public interface IReport
     {
-        void Generate(IReportWriter writer);
+        Task Generate(IReportWriter writer);
 
         void Export(string filename);
     }

--- a/Source/WPF/MyMoney/Reports/NetWorthReport.cs
+++ b/Source/WPF/MyMoney/Reports/NetWorthReport.cs
@@ -134,7 +134,7 @@ namespace Walkabout.Reports
 
                 foreach (Account a in this.myMoney.Accounts.GetAccounts(true))
                 {
-                    if ((a.Type == AccountType.Loan || a.Type == AccountType.Asset) && a.Balance > 0) // then this is a loan out to someone else...(so an asset)
+                    if ((a.Type == AccountType.Loan || a.Type == AccountType.Asset) && a.Balance >= 0) // then this is a loan out to someone else...(so an asset)
                     {
                         color = GetRandomColor();
                         balance = this.myMoney.GetCashBalanceNormalized(this.reportDate, (x) => x == a);

--- a/Source/WPF/MyMoney/Reports/NetWorthReport.cs
+++ b/Source/WPF/MyMoney/Reports/NetWorthReport.cs
@@ -1,14 +1,18 @@
 ﻿using LovettSoftware.Charts;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using Walkabout.Charts;
 using Walkabout.Data;
 using Walkabout.Interfaces.Reports;
+using Walkabout.StockQuotes;
 using Walkabout.Utilities;
+using Walkabout.Views;
 
 namespace Walkabout.Reports
 {
@@ -16,184 +20,214 @@ namespace Walkabout.Reports
     //=========================================================================================
     public class NetWorthReport : Report
     {
+        FlowDocumentView view;
         MyMoney myMoney;
         Random rand = new Random(Environment.TickCount);
         byte minRandColor, maxRandColor;
+        DateTime reportDate;
+        DownloadLog log;
+        Dictionary<Security, decimal> cachedPrices = new Dictionary<Security, decimal>();
+        IDictionary<Security, List<Investment>> transactionsBySecurity;
+        bool generating;
 
         public event EventHandler<SecurityGroup> DrillDown;
 
-        public NetWorthReport(MyMoney money)
+        public NetWorthReport(FlowDocumentView view, MyMoney money, DownloadLog log)
         {
+            this.view = view;
             this.myMoney = money;
+            this.log = log;
+            this.reportDate = DateTime.Today;
             minRandColor = 20;
             maxRandColor = (""+AppTheme.Instance.GetTheme()).Contains("Dark") ? (byte)128: (byte)200;
         }
 
-        public override void Generate(IReportWriter writer)
+        public override async Task Generate(IReportWriter writer)
         {
-            writer.WriteHeading("Net Worth Statement");
-
-            var series = new ChartDataSeries() { Name = "Net Worth" };
-            IList<ChartDataValue> data = series.Values;
-
-            // outer table contains 2 columns, left is the summary table, right is the pie chart.
-            writer.StartTable();
-            writer.StartColumnDefinitions();
-            writer.WriteColumnDefinition("450", 450, 450);
-            writer.WriteColumnDefinition("620", 620, 620);
-            writer.EndColumnDefinitions();
-            writer.StartRow();
-            writer.StartCell();
-    
-            // inner table contains the "data"
-            writer.StartTable();
-            writer.StartColumnDefinitions();
-            writer.WriteColumnDefinition("30", 30, 30);
-            writer.WriteColumnDefinition("300", 300, 300);
-            writer.WriteColumnDefinition("Auto", 100, double.MaxValue);
-            
-            writer.EndColumnDefinitions();
-
-            WriteHeader(writer, "Cash");
-
-            decimal totalBalance = 0;
-            decimal balance = 0;
-            bool hasTaxDeferred = false;
-            bool hasTaxFree = false;
-
-            Transactions transactions = myMoney.Transactions;
-            foreach (Account a in this.myMoney.Accounts.GetAccounts(true))
+            generating = true;
+            try
             {
-                if (a.IsTaxDeferred) hasTaxDeferred = true;
-                if (a.IsTaxFree) hasTaxFree = true;
-                if (a.Type == AccountType.Credit || 
-                    a.Type == AccountType.Asset ||                     
-                    a.Type == AccountType.Brokerage ||
-                    a.Type == AccountType.Retirement ||
-                    a.Type == AccountType.CategoryFund || 
-                    a.Type == AccountType.Loan)
+                FlowDocumentReportWriter fwriter = (FlowDocumentReportWriter)writer;
+                writer.WriteHeading("Net Worth Statement");
+                Paragraph heading = fwriter.CurrentParagraph;
+
+                this.transactionsBySecurity = this.myMoney.GetTransactionsGroupedBySecurity((a) => true, this.reportDate.AddDays(1));
+
+                DatePicker picker = new DatePicker();
+                // byYearCombo.SelectionChanged += OnYearChanged;
+                picker.Margin = new Thickness(10, 0, 0, 0);
+                picker.SelectedDate = this.reportDate;
+                picker.DisplayDate = this.reportDate;
+                picker.SelectedDateChanged += Picker_SelectedDateChanged;
+                heading.Inlines.Add(new InlineUIContainer(picker));
+
+                var series = new ChartDataSeries() { Name = "Net Worth" };
+                IList<ChartDataValue> data = series.Values;
+
+                // outer table contains 2 columns, left is the summary table, right is the pie chart.
+                writer.StartTable();
+                writer.StartColumnDefinitions();
+                writer.WriteColumnDefinition("450", 450, 450);
+                writer.WriteColumnDefinition("620", 620, 620);
+                writer.EndColumnDefinitions();
+                writer.StartRow();
+                writer.StartCell();
+
+                // inner table contains the "data"
+                writer.StartTable();
+                writer.StartColumnDefinitions();
+                writer.WriteColumnDefinition("30", 30, 30);
+                writer.WriteColumnDefinition("300", 300, 300);
+                writer.WriteColumnDefinition("Auto", 100, double.MaxValue);
+
+                writer.EndColumnDefinitions();
+
+                WriteHeader(writer, "Cash");
+
+                decimal totalBalance = 0;
+                bool hasTaxDeferred = false;
+                bool hasTaxFree = false;
+
+                foreach (Account a in this.myMoney.Accounts.GetAccounts(false))
                 {
-                    continue;
+                    if (a.IsTaxDeferred) hasTaxDeferred = true;
+                    if (a.IsTaxFree) hasTaxFree = true;
                 }
 
-                balance += a.BalanceNormalized;
-            }
+                decimal balance = this.myMoney.GetCashBalanceNormalized(this.reportDate, (a) => { return IsBankAccount(a); });
 
-            // Non-investment Cash
-            var color = GetRandomColor();
-            if (balance > 0) data.Add(new ChartDataValue() { Label = "Cash", Value = (double)balance, Color = color });
-            WriteRow(writer, color, "Cash", balance);
-            totalBalance += balance;
+                // Non-investment Cash
+                var color = GetRandomColor();
+                if (balance > 0) data.Add(new ChartDataValue() { Label = "Cash", Value = (double)balance, Color = color });
+                WriteRow(writer, color, "Cash", balance);
+                totalBalance += balance;
 
-            // Investment Cash
-            balance = this.myMoney.GetInvestmentCashBalanceNormalized(new Predicate<Account>((a) => { return !a.IsClosed && IsInvestmentAccount(a); }));
-            color = GetRandomColor();
-            data.Add(new ChartDataValue() { Label = "Investment Cash", Value = (double)balance, Color = color });
-            WriteRow(writer, color, "Investment Cash", balance);
-            totalBalance += balance;
+                // Investment Cash
+                balance = this.myMoney.GetCashBalanceNormalized(this.reportDate, (a) => { return IsInvestmentAccount(a); });
+                color = GetRandomColor();
+                data.Add(new ChartDataValue() { Label = "Investment Cash", Value = (double)balance, Color = color });
+                WriteRow(writer, color, "Investment Cash", balance);
+                totalBalance += balance;
 
-            bool hasNoneTypeTaxDeferred = false;
-            if (hasTaxDeferred)
-            {
-                WriteHeader(writer, "Tax Deferred Assets");
-                totalBalance += WriteSecurities(writer, data, "Tax Deferred ", new Predicate<Account>((a) => { return a.IsTaxDeferred; }), out hasNoneTypeTaxDeferred);
-            }
-
-            bool hasNoneTypeTaxFree = false;
-            if (hasTaxFree)
-            {
-                WriteHeader(writer, "Tax Free Assets");
-                totalBalance += WriteSecurities(writer, data, "Tax Free ", new Predicate<Account>((a) => { return a.IsTaxFree; }), out hasNoneTypeTaxFree);
-            }
-
-            balance = 0;
-
-            WriteHeader(writer, "Other Assets");
-
-            foreach (Account a in this.myMoney.Accounts.GetAccounts(true))
-            {
-                if ((a.Type == AccountType.Loan || a.Type == AccountType.Asset) && a.Balance > 0) // then this is a loan out to someone else...
+                bool hasNoneTypeTaxDeferred = false;
+                Tuple<decimal, bool> r = null;
+                if (hasTaxDeferred)
                 {
-                    color = GetRandomColor();
-                    if (a.BalanceNormalized > 0) data.Add(new ChartDataValue() { Label = a.Name, Value = (double)a.BalanceNormalized, Color = color });
-                    WriteRow(writer, color, a.Name, a.BalanceNormalized);
-                    totalBalance += a.BalanceNormalized;
+                    WriteHeader(writer, "Tax Deferred Assets");
+                    r = await WriteSecurities(writer, data, "Tax Deferred ", new Predicate<Account>((a) => { return a.IsTaxDeferred; }));
+                    totalBalance += r.Item1;
+                    hasNoneTypeTaxDeferred = r.Item2;
                 }
-            }
 
-            bool hasNoneType = false;
-            totalBalance += WriteSecurities(writer, data, "", new Predicate<Account>((a) => { return IsInvestmentAccount(a) && !a.IsTaxDeferred && !a.IsTaxFree; }), out hasNoneType);
-
-            balance = 0;
-            WriteHeader(writer, "Liabilities");
-
-            foreach (Account a in this.myMoney.Accounts.GetAccounts(true))
-            {
-                if (a.Type != AccountType.Credit)
+                bool hasNoneTypeTaxFree = false;
+                if (hasTaxFree)
                 {
-                    continue;
+                    WriteHeader(writer, "Tax Free Assets");
+                    r = await WriteSecurities(writer, data, "Tax Free ", new Predicate<Account>((a) => { return a.IsTaxFree; }));
+                    totalBalance += r.Item1;
+                    hasNoneTypeTaxFree = r.Item2;
                 }
-                balance += a.BalanceNormalized;
-            }
-            totalBalance += balance;
 
-            color = GetRandomColor();
-            if (balance > 0) data.Add(new ChartDataValue() { Label = "Credit", Value = (double)balance, Color = color });
-            WriteRow(writer, color, "Credit", balance);
-            balance = 0;
-            foreach (Account a in this.myMoney.Accounts.GetAccounts(true))
-            {
-                if (a.Type == AccountType.Loan && a.BalanceNormalized < 0)
+                balance = 0;
+
+                WriteHeader(writer, "Other Assets");
+
+                foreach (Account a in this.myMoney.Accounts.GetAccounts(true))
                 {
-                    balance += a.BalanceNormalized;
-                    color = GetRandomColor();
-                    if (a.BalanceNormalized > 0) data.Add(new ChartDataValue() { Label = a.Name, Value = (double)a.BalanceNormalized, Color = color });
-                    WriteRow(writer, color, a.Name, a.BalanceNormalized);
+                    if ((a.Type == AccountType.Loan || a.Type == AccountType.Asset) && a.Balance > 0) // then this is a loan out to someone else...(so an asset)
+                    {
+                        color = GetRandomColor();
+                        balance = this.myMoney.GetCashBalanceNormalized(this.reportDate, (x) => x == a);
+                        if (balance > 0) data.Add(new ChartDataValue() { Label = a.Name, Value = (double)balance, Color = color });
+                        WriteRow(writer, color, a.Name, balance);
+                        totalBalance += balance;
+                    }
                 }
-            }
-            totalBalance += balance;
 
-            writer.StartFooterRow();
+                r = await WriteSecurities(writer, data, "", new Predicate<Account>((a) => { return IsInvestmentAccount(a) && !a.IsTaxDeferred && !a.IsTaxFree; }));
+                totalBalance += r.Item1;
+                bool hasNoneType = r.Item2;
 
-            writer.StartCell(1,2);
-            writer.WriteParagraph("Total");
-            writer.EndCell();
+                // liabilities are not included in the pie chart because that would be confusing.
+                balance = this.myMoney.GetCashBalanceNormalized(this.reportDate, (a) => a.Type == AccountType.Credit);
+                WriteHeader(writer, "Liabilities");
+                totalBalance += balance;
 
-            writer.StartCell();
-            writer.WriteNumber(totalBalance.ToString("C"));
-            writer.EndCell();
+                color = GetRandomColor();
+                WriteRow(writer, color, "Credit", balance);
+                balance = 0;
+                foreach (Account a in this.myMoney.Accounts.GetAccounts(true))
+                {
+                    if (a.Type == AccountType.Loan && a.BalanceNormalized < 0) // loan we owe, so a liability!
+                    {
+                        balance = this.myMoney.GetCashBalanceNormalized(this.reportDate, (x) => x == a);
+                        color = GetRandomColor();
+                        WriteRow(writer, color, a.Name, balance);
+                        totalBalance += balance;
+                    }
+                }
 
-            writer.EndRow();
-            writer.EndTable();
+                writer.StartFooterRow();
 
-            writer.EndCell();
-            writer.StartCell();
+                writer.StartCell(1, 2);
+                writer.WriteParagraph("Total");
+                writer.EndCell();
+
+                writer.StartCell();
+                writer.WriteNumber(totalBalance.ToString("C"));
+                writer.EndCell();
+
+                writer.EndRow();
+                writer.EndTable();
+
+                writer.EndCell();
+                writer.StartCell();
 
 
-            // pie chart
-            AnimatingPieChart chart = new AnimatingPieChart();
-            chart.Width = 600;
-            chart.Height = 400;
-            chart.BorderThickness = new Thickness(0);
-            chart.VerticalAlignment = VerticalAlignment.Top;
-            chart.Series = series;
-            chart.ToolTipGenerator = OnGenerateToolTip;
-            chart.PieSliceClicked += OnPieSliceClicked;
+                // pie chart
+                AnimatingPieChart chart = new AnimatingPieChart();
+                chart.Width = 600;
+                chart.Height = 400;
+                chart.BorderThickness = new Thickness(0);
+                chart.VerticalAlignment = VerticalAlignment.Top;
+                chart.Series = series;
+                chart.ToolTipGenerator = OnGenerateToolTip;
+                chart.PieSliceClicked += OnPieSliceClicked;
 
-            writer.WriteElement(chart);
+                writer.WriteElement(chart);
 
-            writer.EndCell();
-            writer.EndRow();
-            writer.EndTable();
+                writer.EndCell();
+                writer.EndRow();
+                writer.EndTable();
 
-            if (hasNoneTypeTaxDeferred || hasNoneTypeTaxFree || hasNoneType)
+                if (hasNoneTypeTaxDeferred || hasNoneTypeTaxFree || hasNoneType)
+                {
+                    writer.WriteParagraph("(*) One ore more of your securities has no SecurityType, you can fix this using View/Securities",
+                        System.Windows.FontStyles.Italic, System.Windows.FontWeights.Normal, System.Windows.Media.Brushes.Maroon);
+                }
+
+                writer.WriteParagraph("Generated for " + this.reportDate.ToLongDateString(), System.Windows.FontStyles.Italic, System.Windows.FontWeights.Normal, System.Windows.Media.Brushes.Gray);
+            } 
+            finally
             {
-                writer.WriteParagraph("(*) One ore more of your securities has no SecurityType, you can fix this using View/Securities", 
-                    System.Windows.FontStyles.Italic, System.Windows.FontWeights.Normal, System.Windows.Media.Brushes.Maroon);
+                generating = false;
             }
-
-            writer.WriteParagraph("Generated on " + DateTime.Today.ToLongDateString(), System.Windows.FontStyles.Italic, System.Windows.FontWeights.Normal, System.Windows.Media.Brushes.Gray);
         }
+
+        private void Picker_SelectedDateChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!generating)
+            {
+                DatePicker picker = (DatePicker)sender;
+                if (picker.SelectedDate.HasValue)
+                {
+                    this.cachedPrices = new Dictionary<Security, decimal>();
+                    this.reportDate = picker.SelectedDate.Value;
+                    _ = view.Generate(this);
+                }
+            }
+        }
+
         private void OnPieSliceClicked(object sender, ChartDataValue e)
         {
             if (e.UserData is SecurityGroup g && DrillDown != null)
@@ -211,14 +245,70 @@ namespace Walkabout.Reports
             return tip;
         }
 
-        private decimal WriteSecurities(IReportWriter writer, IList<ChartDataValue> data, string prefix, Predicate<Account> filter, out bool hasNoneType)
+        private async Task<decimal> GetSecurityPrice(DateTime date, Security s)
         {
-            hasNoneType = false;
+            // return the closing price of the given security for this date.
+            if (date.Date == DateTime.Today.Date)
+            {
+                return s.Price;
+            }
+
+            if (this.cachedPrices.TryGetValue(s, out decimal price))
+            {
+                return price;
+            }
+
+            // find the price in the download log if we have one.
+            var symbol = s.Symbol;
+            if (!string.IsNullOrEmpty(symbol))
+            {
+                var history = await this.log.GetHistory(symbol);
+                if (history != null && history.History != null && history.History.Count > 0)
+                {
+                    foreach (var item in history.History)
+                    {
+                        if (item.Date > date)
+                        {
+                            break;
+                        }
+                        price = item.Close;
+                    }
+                }
+            }
+
+            // hmmm, then we have to search our own transactions for a recorded UnitPrice.
+            if (price == 0 && transactionsBySecurity.TryGetValue(s, out List<Investment> trades) && trades != null)
+            {
+                price = 0;
+                foreach (var t in trades)
+                {
+                    if (t.Date > date)
+                    {
+                        break;
+                    }
+                    if (t.UnitPrice != 0)
+                    {
+                        price = t.UnitPrice;
+                    }
+                }
+            }
+
+            if (price != 0)
+            {
+                this.cachedPrices[s] = price;
+            }
+            return price;
+        }
+
+
+        private async Task<Tuple<decimal, bool>> WriteSecurities(IReportWriter writer, IList<ChartDataValue> data, string prefix, Predicate<Account> filter)
+        {
+            bool hasNoneType = false;
             decimal balance = 0;
             Dictionary<SecurityType, decimal> byType = new Dictionary<SecurityType, decimal>();
             Dictionary<SecurityType, SecurityGroup> groupsByType = new Dictionary<SecurityType, SecurityGroup>();
 
-            CostBasisCalculator calc = new CostBasisCalculator(this.myMoney, DateTime.Now);
+            CostBasisCalculator calc = new CostBasisCalculator(this.myMoney, this.reportDate);
 
             // compute summary
             foreach (var securityTypeGroup in calc.GetHoldingsBySecurityType(filter))
@@ -229,7 +319,7 @@ namespace Walkabout.Reports
 
                 foreach (SecurityPurchase sp in securityTypeGroup.Purchases)
                 {                    
-                    sb += sp.MarketValue;
+                    sb += sp.UnitsRemaining * await GetSecurityPrice(this.reportDate, sp.Security);
                 }
                 byType[stype] = sb;
                 groupsByType[stype] = securityTypeGroup;
@@ -266,7 +356,21 @@ namespace Walkabout.Reports
             {
                 WriteRow(writer, GetRandomColor(), "N/A", 0);
             }
-            return balance;
+            return new Tuple<decimal, bool>(balance, hasNoneType);
+        }
+
+        bool IsBankAccount(Account a)
+        {
+            if (a.Type == AccountType.Credit || // we'll show credit accounts as liabilities later.
+                a.Type == AccountType.Asset ||
+                a.Type == AccountType.Brokerage ||
+                a.Type == AccountType.Retirement ||
+                a.Type == AccountType.CategoryFund ||
+                a.Type == AccountType.Loan)
+            {
+                return false;
+            }
+            return true;
         }
 
         bool IsInvestmentAccount(Account a)

--- a/Source/WPF/MyMoney/Reports/PortfolioReport.cs
+++ b/Source/WPF/MyMoney/Reports/PortfolioReport.cs
@@ -1,6 +1,7 @@
 ﻿using LovettSoftware.Charts;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -114,7 +115,7 @@ namespace Walkabout.Reports
             writer.EndRow();
         }
 
-        public override void Generate(IReportWriter writer)
+        public override Task Generate(IReportWriter writer)
         {
             flowwriter = writer as FlowDocumentReportWriter;
 
@@ -234,6 +235,7 @@ namespace Walkabout.Reports
                     WriteDetails(writer, "", new Predicate<Account>((a) => { return a == account; }));
                 }
             }
+            return Task.CompletedTask;
         }
 
         bool IsInvestmentAccount(Account a)

--- a/Source/WPF/MyMoney/Reports/PortfolioReport.cs
+++ b/Source/WPF/MyMoney/Reports/PortfolioReport.cs
@@ -12,6 +12,7 @@ using Walkabout.Charts;
 using Walkabout.Data;
 using Walkabout.Interfaces.Reports;
 using Walkabout.Interfaces.Views;
+using Walkabout.StockQuotes;
 
 namespace Walkabout.Reports
 {
@@ -27,6 +28,7 @@ namespace Walkabout.Reports
         Paragraph mouseDownPara;
         Point downPos;
         DateTime reportDate;
+        StockQuoteCache cache;
         SecurityGroup selectedGroup;
         Random rand = new Random(Environment.TickCount);
 
@@ -45,6 +47,7 @@ namespace Walkabout.Reports
             this.view = view;
             this.reportDate = asOfDate;
             this.selectedGroup = g;
+            this.cache = (StockQuoteCache)serviceProvider.GetService(typeof(StockQuoteCache));
             view.PreviewMouseLeftButtonUp -= OnPreviewMouseLeftButtonUp;
             view.PreviewMouseLeftButtonUp += OnPreviewMouseLeftButtonUp;
             view.Unloaded += (s, e) =>
@@ -166,13 +169,13 @@ namespace Walkabout.Reports
             {
                 if (this.selectedGroup != null)
                 {
-                    WriteSummary(writer, data, TaxStatus.Taxable, null, null, false);
+                    WriteSummary(writer, data, this.selectedGroup.TaxStatus, null, null, false);
                 }
                 else
                 {
-                    WriteSummary(writer, data, TaxStatus.TaxFree, "Tax Free ", new Predicate<Account>((a) => { return !a.IsClosed && a.IsTaxFree && IsInvestmentAccount(a); }), true);
-                    WriteSummary(writer, data, TaxStatus.TaxDeferred, "Tax Deferred ", new Predicate<Account>((a) => { return !a.IsClosed && a.IsTaxDeferred && IsInvestmentAccount(a);  }), true);
-                    WriteSummary(writer, data, TaxStatus.Taxable, "Taxable ", new Predicate<Account>((a) => { return !a.IsClosed && !a.IsTaxDeferred && !a.IsTaxFree && IsInvestmentAccount(a); }), true);
+                    WriteSummary(writer, data, TaxStatus.TaxFree, "Tax Free ", new Predicate<Account>((a) => { return a.IsTaxFree && IsInvestmentAccount(a); }), true);
+                    WriteSummary(writer, data, TaxStatus.TaxDeferred, "Tax Deferred ", new Predicate<Account>((a) => { return a.IsTaxDeferred && IsInvestmentAccount(a);  }), true);
+                    WriteSummary(writer, data, TaxStatus.Taxable, "Taxable ", new Predicate<Account>((a) => { return !a.IsTaxDeferred && !a.IsTaxFree && IsInvestmentAccount(a); }), true);
                 }
             }
             else
@@ -209,7 +212,7 @@ namespace Walkabout.Reports
 
             if (this.selectedGroup != null)
             {
-                WriteDetails(writer, "", this.selectedGroup);
+                WriteDetails(writer, this.selectedGroup.TaxStatus, this.selectedGroup);
             }
             else
             {
@@ -226,13 +229,13 @@ namespace Walkabout.Reports
 
                 if (account == null)
                 {
-                    WriteDetails(writer, "Tax Free ", new Predicate<Account>((a) => { return !a.IsClosed && a.IsTaxFree && IsInvestmentAccount(a);}));
-                    WriteDetails(writer, "Tax Deferred ", new Predicate<Account>((a) => { return !a.IsClosed && a.IsTaxDeferred && IsInvestmentAccount(a); }));
-                    WriteDetails(writer, "Taxable ", new Predicate<Account>((a) => { return !a.IsClosed && !a.IsTaxFree && !a.IsTaxDeferred && IsInvestmentAccount(a); }));
+                    WriteDetails(writer, TaxStatus.TaxFree, new Predicate<Account>((a) => { return a.IsTaxFree && IsInvestmentAccount(a);}));
+                    WriteDetails(writer, TaxStatus.TaxDeferred, new Predicate<Account>((a) => { return a.IsTaxDeferred && IsInvestmentAccount(a); }));
+                    WriteDetails(writer, TaxStatus.Taxable, new Predicate<Account>((a) => { return !a.IsTaxFree && !a.IsTaxDeferred && IsInvestmentAccount(a); }));
                 }
                 else
                 {
-                    WriteDetails(writer, "", new Predicate<Account>((a) => { return a == account; }));
+                    WriteDetails(writer, TaxStatus.Any, new Predicate<Account>((a) => { return a == account; }));
                 }
             }
             return Task.CompletedTask;
@@ -287,7 +290,7 @@ namespace Walkabout.Reports
                 // as a gain or loss, it will be accounted for under MarketValue, but it will be misleading as a "Gain".  So we tweak the value here.
                 decimal gain = (i.CostBasisPerUnit == 0) ? 0 : i.GainLoss;
 
-                marketValue += i.MarketValue;
+                marketValue += i.FuturesFactor * i.UnitsRemaining * this.cache.GetSecurityMarketPrice(this.reportDate, i.Security);
                 costBasis += i.TotalCostBasis;
                 gainLoss += gain;
                 currentQuantity += i.UnitsRemaining;
@@ -313,7 +316,8 @@ namespace Walkabout.Reports
                 // for tax reporting we need to report the real GainLoss, but if CostBasis is zero then it doesn't make sense to report something
                 // as a gain or loss, it will be accounted for under MarketValue, but it will be misleading as a "Gain".  So we tweak the value here.
                 decimal gain = (i.CostBasisPerUnit == 0) ? 0 : i.GainLoss;
-                WriteRow(writer, false, false, FontWeights.Normal, i.DatePurchased, i.Security.Name, i.Security.Name, i.UnitsRemaining, i.CostBasisPerUnit, i.MarketValue, i.Security.Price, i.TotalCostBasis, gain);
+                marketValue = this.cache.GetSecurityMarketPrice(this.reportDate, i.Security);
+                WriteRow(writer, false, false, FontWeights.Normal, i.DatePurchased, i.Security.Name, i.Security.Name, i.UnitsRemaining, i.CostBasisPerUnit, marketValue, i.Security.Price, i.TotalCostBasis, gain);
             }
 
             writer.EndExpandableRowGroup();
@@ -335,22 +339,40 @@ namespace Walkabout.Reports
             }
         }
 
-        private void WriteDetails(IReportWriter writer, string prefix, Predicate<Account> filter)
+        private void WriteDetails(IReportWriter writer, TaxStatus status, Predicate<Account> filter)
         {
             // compute summary
-            foreach (var securityTypeGroup in calc.GetHoldingsBySecurityType(filter))
+            foreach (var securityTypeGroup in calc.GetHoldingsBySecurityType(status, filter))
             {
-                WriteDetails(writer, prefix, securityTypeGroup);
+                WriteDetails(writer, status, securityTypeGroup);
             }
         }
 
-        private void WriteDetails(IReportWriter writer, string prefix, SecurityGroup securityTypeGroup)
+        private void WriteDetails(IReportWriter writer, TaxStatus status, SecurityGroup securityTypeGroup)
         {
             decimal marketValue = 0;
             decimal costBasis = 0;
             decimal gainLoss = 0;
             bool foundSecuritiesInGroup = false;
             SecurityType st = securityTypeGroup.Type;
+
+            string prefix = "";
+            switch (status)
+            {
+                case TaxStatus.Taxable:
+                    prefix = "Taxable ";
+                    break;
+                case TaxStatus.TaxDeferred:
+                    prefix = "Tax Deferred ";
+                    break;
+                case TaxStatus.TaxFree:
+                    prefix = "Tax Free ";
+                    break;
+                case TaxStatus.Any:
+                    break;
+                default:
+                    break;
+            }
 
             string caption = prefix + Security.GetSecurityTypeCaption(st);
 
@@ -419,7 +441,7 @@ namespace Walkabout.Reports
             }
             else
             {
-                groups = calc.GetHoldingsBySecurityType(filter);
+                groups = calc.GetHoldingsBySecurityType(taxStatus, filter);
             }
 
             // compute summary
@@ -434,7 +456,7 @@ namespace Walkabout.Reports
                 {
                     if (i.UnitsRemaining > 0)
                     {
-                        marketValue += i.MarketValue;
+                        marketValue += i.FuturesFactor * i.UnitsRemaining * this.cache.GetSecurityMarketPrice(this.reportDate, i.Security);
                         gainLoss += i.GainLoss;
                         count++;
                     }

--- a/Source/WPF/MyMoney/Reports/Reports.cs
+++ b/Source/WPF/MyMoney/Reports/Reports.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Win32;
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
@@ -13,7 +14,7 @@ namespace Walkabout.Reports
 {
     public abstract class Report : IReport
     {
-        public abstract void Generate(IReportWriter writer);
+        public abstract Task Generate(IReportWriter writer);
 
         public virtual void Export(string filename)
         {

--- a/Source/WPF/MyMoney/Reports/TaxReport.cs
+++ b/Source/WPF/MyMoney/Reports/TaxReport.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -51,7 +52,7 @@ namespace Walkabout.Reports
             this.endDate = this.startDate.AddYears(1);
         }
 
-        public override void Generate(IReportWriter writer)
+        public override Task Generate(IReportWriter writer)
         {
             FlowDocumentReportWriter fwriter = (FlowDocumentReportWriter)writer;
             writer.WriteHeading("Tax Report For ");
@@ -160,6 +161,7 @@ namespace Walkabout.Reports
 
             FlowDocument document = view.DocumentViewer.Document;
             document.Blocks.InsertAfter(document.Blocks.FirstBlock, new BlockUIContainer(CreateExportTxfButton()));
+            return Task.CompletedTask;
         }
 
         void WriteHeaders(IReportWriter writer)
@@ -207,7 +209,7 @@ namespace Walkabout.Reports
         {
             CheckBox checkBox = (CheckBox)sender;
             this.capitalGainsOnly = checkBox.IsChecked == true;
-            view.Generate(this);
+            _ = view.Generate(this);
         }
 
         private void OnConsolidateComboSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -215,7 +217,7 @@ namespace Walkabout.Reports
             ComboBox box = (ComboBox)sender;
             int index = (int)box.SelectedIndex;
             this.consolidateOnDateSold = index == 1;
-            view.Generate(this);
+            _ = view.Generate(this);
         }
 
         private void OnYearChanged(object sender, SelectionChangedEventArgs e)
@@ -229,7 +231,7 @@ namespace Walkabout.Reports
             if (int.TryParse(label, out int year))
             {
                 SetStartDate(year);
-                view.Generate(this);
+                _ = view.Generate(this);
             }
         }
 

--- a/Source/WPF/MyMoney/Reports/UnacceptedReport.cs
+++ b/Source/WPF/MyMoney/Reports/UnacceptedReport.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Walkabout.Data;
 using Walkabout.Interfaces.Reports;
 
@@ -16,7 +17,7 @@ namespace Walkabout.Reports
             this.myMoney = money;
         }
 
-        public override void Generate(IReportWriter writer)
+        public override Task Generate(IReportWriter writer)
         {
             writer.WriteHeading("Unaccepted Transactions");
 
@@ -69,6 +70,7 @@ namespace Walkabout.Reports
             writer.EndTable();
 
             writer.WriteParagraph("Generated on " + DateTime.Today.ToLongDateString(), System.Windows.FontStyles.Italic, System.Windows.FontWeights.Normal, System.Windows.Media.Brushes.Gray);
+            return Task.CompletedTask;
         }
 
         private static void WriteRow(IReportWriter writer, string col1, string col2, string col3)

--- a/Source/WPF/MyMoney/Reports/W2Report.cs
+++ b/Source/WPF/MyMoney/Reports/W2Report.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -80,7 +81,7 @@ namespace Walkabout.Taxes
 
         public void Regenerate()
         {
-            view.Generate(this);
+            _ = view.Generate(this);
         }
 
         private bool Summarize(Dictionary<Category, decimal> byCategory, Transaction t)
@@ -130,7 +131,7 @@ namespace Walkabout.Taxes
             }
         }
 
-        public override void Generate(IReportWriter writer)
+        public override Task Generate(IReportWriter writer)
         {
             this.transactionsByCategory = new Dictionary<Category, List<Transaction>>();
             FlowDocumentReportWriter fwriter = (FlowDocumentReportWriter)writer;
@@ -202,7 +203,7 @@ namespace Walkabout.Taxes
             }
 
             writer.WriteParagraph("Generated on " + DateTime.Today.ToLongDateString(), System.Windows.FontStyles.Italic, System.Windows.FontWeights.Normal, System.Windows.Media.Brushes.Gray);
-
+            return Task.CompletedTask;
         }
 
         bool GenerateForm(TaxForm form, IReportWriter writer, ICollection<Transaction> transactions)

--- a/Source/WPF/MyMoney/Setup/ChangeInfoFormatter.cs
+++ b/Source/WPF/MyMoney/Setup/ChangeInfoFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -79,9 +80,9 @@ namespace Walkabout.Setup
             return false;
         }
 
-        public override void Generate(IReportWriter writer) 
+        public override Task Generate(IReportWriter writer) 
         {
-            if (doc == null) return;
+            if (doc == null) return Task.CompletedTask;
 
             var document = view.DocumentViewer.Document;
 
@@ -134,6 +135,7 @@ namespace Walkabout.Setup
             {
                 document.Blocks.InsertAfter(document.Blocks.FirstBlock, new BlockUIContainer(CreateInstallButton()));
             }
+            return Task.CompletedTask;
         }
 
         private Button CreateInstallButton()

--- a/Source/WPF/MyMoney/StockQuotes/StockQuoteCache.cs
+++ b/Source/WPF/MyMoney/StockQuotes/StockQuoteCache.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Walkabout.Data;
+
+namespace Walkabout.StockQuotes
+{
+    /// <summary>
+    /// Provides an efficient lookup of the market price of a given security at the given date.
+    /// </summary>
+    public class StockQuoteCache
+    {
+        MyMoney myMoney;
+        DownloadLog log;
+        IDictionary<Security, List<Investment>> transactionsBySecurity;
+        HashSet<Security> changed;
+        long lockCount;
+
+        // For an O(1) Date => StockQuote lookup, so we index the stock quote history in a Dictionary here.
+        Dictionary<Security, StockQuoteIndex> quoteIndex = new Dictionary<Security, StockQuoteIndex>();
+
+        public StockQuoteCache(MyMoney money, DownloadLog log)
+        {
+            this.myMoney = money;
+            this.log = log;
+            this.myMoney.Securities.Changed += Securities_Changed;
+        }
+
+        private void Securities_Changed(object sender, ChangeEventArgs e)
+        {
+            while (e != null)
+            {
+                if (e.Item is Security s)
+                {
+                    if (lockCount > 0)
+                    {
+                        if (changed == null)
+                        {
+                            changed = new HashSet<Security>();
+                        }
+                        changed.Add(s);
+                    }
+                    else
+                    {
+                        OnSecurityChanged(s);
+                    }
+                }
+                e = e.Next;
+            }
+        }
+
+        private void OnSecurityChanged(Security s)
+        {
+            if (quoteIndex.ContainsKey(s))
+            {
+                quoteIndex.Remove(s);
+            }
+            if (transactionsBySecurity.ContainsKey(s))
+            {
+                transactionsBySecurity.Remove(s);
+            }
+        }
+
+        public IDisposable BeginLock()
+        {
+            lockCount++;
+            return new UpdateLock(this);
+        }
+
+        private void ReleaseLock()
+        {
+            lockCount--;
+            if (lockCount <= 0)
+            {
+                lockCount = 0;
+                var snapshot = changed;
+                changed = null;
+                if (snapshot != null)
+                {
+                    foreach (var s in snapshot)
+                    {
+                        OnSecurityChanged(s);
+                    }
+                }
+            }
+        }
+
+        public decimal GetSecurityMarketPrice(DateTime date, Security s)
+        {
+            // return the closing price of the given security for this date.
+            if (date.Date == DateTime.Today.Date)
+            {
+                return s.Price;
+            }
+
+            decimal price = 0;
+            if (quoteIndex.TryGetValue(s, out StockQuoteIndex index))
+            { 
+                var quote = index.GetQuote(date);
+                if (quote != null)
+                {
+                    price = quote.Close;
+                }
+            }
+            else
+            {
+                // create an empty index that we can update below.
+                quoteIndex[s] = index = new StockQuoteIndex(null);
+            }
+
+            // hmmm, then we have to search our own transactions for a recorded UnitPrice.
+            if (price == 0)
+            {
+                if (this.transactionsBySecurity == null)
+                {
+                    this.transactionsBySecurity = this.myMoney.GetTransactionsGroupedBySecurity((a) => true, date.AddDays(1));
+                }
+
+                if (transactionsBySecurity.TryGetValue(s, out List<Investment> trades) && trades != null)
+                {
+                    price = 0;
+                    foreach (var t in trades)
+                    {
+                        if (t.Date > date)
+                        {
+                            break;
+                        }
+                        if (t.UnitPrice != 0)
+                        {
+                            price = t.UnitPrice;
+                        }
+                    }
+                }
+            }
+
+            if (price != 0)
+            {
+                index.SetQuote(date, price);
+            }
+            return price;
+        }
+
+        internal async Task LoadHistory(Security s)
+        {
+            if (!quoteIndex.TryGetValue(s, out StockQuoteIndex index))
+            {
+                StockQuoteHistory history = null;
+                if (!string.IsNullOrEmpty(s.Symbol))
+                {
+                    // find the prices in the download log if we have one.
+                    history = await this.log.GetHistory(s.Symbol);
+                }
+                index = new StockQuoteIndex(history);
+                quoteIndex[s] = index;
+            }
+        }
+
+        /// <summary>
+        /// Use this method to provide stock quote info from Transactions in the case that
+        /// you have a security that has no download stock price history, which can happen
+        /// with custom securities that are not publicly traded.
+        /// </summary>
+        internal void SetQuote(DateTime date, Security security, decimal price)
+        {
+            if (!quoteIndex.TryGetValue(security, out StockQuoteIndex index))
+            {
+                // create an empty index that we can update below.
+                quoteIndex[security] = new StockQuoteIndex(null);
+            }
+            quoteIndex[security].SetQuote(date, price);
+        }
+
+        internal class StockQuoteIndex
+        {
+            Dictionary<DateTime, StockQuote> index = new Dictionary<DateTime, StockQuote>();
+            
+            public StockQuoteIndex(StockQuoteHistory history)
+            {
+                if (history != null)
+                {
+                    foreach (var quote in history.GetSorted())
+                    {
+                        index[quote.Date] = quote;
+                    }
+                }
+            }
+
+            public void SetQuote(DateTime date, decimal price)
+            {
+                index[date] = new StockQuote() { Close = price, Date = date };
+            }
+
+            public StockQuote GetQuote(DateTime date)
+            {
+                if (index.Count != 0)
+                {
+                    for (int i = 7; i > 0; i--)
+                    {
+                        if (index.TryGetValue(date, out StockQuote value))
+                        {
+                            return value;
+                        }
+                        // go back at most a week looking for an open stock market!
+                        date = date.AddDays(-1);
+                    }
+                }
+                return null;
+            }
+        }
+
+        class UpdateLock : IDisposable
+        {
+            StockQuoteCache parent;
+            public UpdateLock(StockQuoteCache parent)
+            {
+                this.parent = parent;
+            }
+
+            public void Dispose()
+            {
+                this.parent.ReleaseLock();
+            }
+        }
+
+    }
+}

--- a/Source/WPF/MyMoney/StockQuotes/StockQuoteCache.cs
+++ b/Source/WPF/MyMoney/StockQuotes/StockQuoteCache.cs
@@ -57,7 +57,7 @@ namespace Walkabout.StockQuotes
             {
                 quoteIndex.Remove(s);
             }
-            if (transactionsBySecurity.ContainsKey(s))
+            if (transactionsBySecurity != null && transactionsBySecurity.ContainsKey(s))
             {
                 transactionsBySecurity.Remove(s);
             }

--- a/Source/WPF/MyMoney/Views/FlowDocumentView.xaml
+++ b/Source/WPF/MyMoney/Views/FlowDocumentView.xaml
@@ -42,6 +42,7 @@
                             <Image x:Name="ToggleExpandAllImage" Width="16" Height="16" Source="{DynamicResource ExpandAllIcon}" VerticalAlignment="Center" HorizontalAlignment="Center" SnapsToDevicePixels="True" 
                                    />
                         </ToggleButton>
+
                     </StackPanel>
 
                     <StackPanel x:Name="SearchWidgetArea"  Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,2,2,2" VerticalAlignment="Center" >

--- a/Source/WPF/MyMoney/Views/FlowDocumentView.xaml.cs
+++ b/Source/WPF/MyMoney/Views/FlowDocumentView.xaml.cs
@@ -49,8 +49,26 @@ namespace Walkabout.Views
             ButtonStrip.Children.Add(control);
         }
 
+        bool generatingReport;
+
         public async Task Generate(IReport report)
         {
+            if (!generatingReport)
+            {
+                generatingReport = true;
+                try
+                {
+                    await InternalGenerate(report);
+                }
+                finally
+                {
+                    generatingReport = false;
+                }
+            }
+        }
+
+        private async Task InternalGenerate(IReport report)
+        { 
             this.report = report;
             this.Viewer.Document.Blocks.Clear();
             this.writer = null;

--- a/Source/WPF/MyMoney/Views/FlowDocumentView.xaml.cs
+++ b/Source/WPF/MyMoney/Views/FlowDocumentView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -48,25 +49,24 @@ namespace Walkabout.Views
             ButtonStrip.Children.Add(control);
         }
 
-        public void Generate(IReport report)
+        public async Task Generate(IReport report)
         {
             this.report = report;
             this.Viewer.Document.Blocks.Clear();
+            this.writer = null;
+            ResetExpandAllToggleButton();
 
             Paragraph p = new Paragraph();
             p.Inlines.Add(new Run() { Text = "Loading..." });
             p.FontSize = 18;
             this.Viewer.Document.Blocks.Add(p);
 
-            this.Viewer.Dispatcher.BeginInvoke(new Action(() =>
-            {
-                var pixelsPerDip = VisualTreeHelper.GetDpi(this).PixelsPerDip;
-                FlowDocumentReportWriter writer = new FlowDocumentReportWriter(this.Viewer.Document, pixelsPerDip);
-                report.Generate(writer);
-                this.writer = writer;
-                ResetExpandAllToggleButton();
-                OnAfterViewStateChanged();
-            }), DispatcherPriority.ContextIdle);
+            var pixelsPerDip = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+            FlowDocumentReportWriter writer = new FlowDocumentReportWriter(this.Viewer.Document, pixelsPerDip);
+            await report.Generate(writer);
+            this.writer = writer;
+            ResetExpandAllToggleButton();
+            OnAfterViewStateChanged();
         }
 
         public FlowDocumentScrollViewer DocumentViewer
@@ -141,7 +141,7 @@ namespace Walkabout.Views
             { 
                 if (value is ReportViewState r)
                 {
-                    this.Generate(r.report);
+                    _ = this.Generate(r.report);
                 }
             }
         }
@@ -245,7 +245,7 @@ namespace Walkabout.Views
         {
             if (resetting) return;
             ToggleExpandAll.ToolTip = "Hide Details";
-            writer.ExpandAll();
+            if (writer != null) writer.ExpandAll();
             ToggleExpandAllImage.SetResourceReference(Image.SourceProperty, "CollapseAllIcon");
         }
 
@@ -253,13 +253,13 @@ namespace Walkabout.Views
         {
             if (resetting) return;
             ToggleExpandAll.ToolTip = "Show Details";
-            writer.CollapseAll();
+            if (writer != null) writer.CollapseAll();
             ToggleExpandAllImage.SetResourceReference(Image.SourceProperty, "ExpandAllIcon");
         }
         void ResetExpandAllToggleButton()
         {
             resetting = true;
-            this.ToggleExpandAll.IsEnabled = writer.CanExpandCollapse;
+            this.ToggleExpandAll.IsEnabled = (writer != null) ? writer.CanExpandCollapse : false;
             this.ToggleExpandAll.ToolTip = "Show Details";
             this.ToggleExpandAll.IsChecked = false;
             ToggleExpandAllImage.SetResourceReference(Image.SourceProperty, "ExpandAllIcon");

--- a/Source/WPF/MyMoney/Views/TransactionsView.xaml
+++ b/Source/WPF/MyMoney/Views/TransactionsView.xaml
@@ -826,6 +826,9 @@
                     <!-- DEPOSIT -->
                     <views:TransactionAmountColumn Header="Deposit" SortMemberPath="Credit"/>
 
+                    <!-- BALANCE -->
+                    <views:TransactionNumericColumn Header="Cash Balance" SortMemberPath="Balance" IsReadOnly="True"/>
+
                     <!-- ANCHOR -->
                     <views:TransactionAnchorColumn IsReadOnly="True"/>
                 </DataGrid.Columns>

--- a/Source/WPF/MyMoney/Views/TransactionsView.xaml.cs
+++ b/Source/WPF/MyMoney/Views/TransactionsView.xaml.cs
@@ -2263,7 +2263,7 @@ namespace Walkabout.Views
             DateTime reportDate = this.IsReconciling ? GetReconiledExclusiveEndDate() : DateTime.Now;
             PortfolioReport report = new PortfolioReport(view, this.myMoney, account, this.ServiceProvider, reportDate, null);
             report.DrillDown += OnReportDrillDown;
-            view.Generate(report);
+            _ = view.Generate(report);
             portfolioReport = report;
         }
 
@@ -2279,7 +2279,7 @@ namespace Walkabout.Views
             HelpService.SetHelpKeyword(view, "Investment Portfolio");
             DateTime reportDate = this.IsReconciling ? GetReconiledExclusiveEndDate() : DateTime.Now;
             PortfolioReport report = new PortfolioReport(view, this.myMoney, null, this.ServiceProvider, reportDate, e);
-            view.Generate(report);
+            _ = view.Generate(report);
             FireAfterViewStateChanged(SelectedRowId);
         }
 


### PR DESCRIPTION
This adds a DatePicker to the NetworthReport which will then do it's best to compute your historical NetWorth on the given date. It will use Online StockQuote history to get accurate stock values if possible, else it will fall back on the most recent UnitPrice recorded in your transactions.

If you own a lot of stocks and have a lot of XML files in your StockQuotes cache folder, you will see some delay in generating the report while it is loading these files, but that's a one time delay since the downloaded quotes are then cached in memory so as you pick different dates it will get faster, although the further back you go in time it is also likely to have to load new .XML files for stocks you no longer own but you did own them back then.

The Drilldown from NetWorth to Portfolio reports remembers this same report date, and shows the portfolio using stock quote values from that date.